### PR TITLE
chore: remove additional sensitive fields from `WorkspaceOwner`

### DIFF
--- a/types/owner.go
+++ b/types/owner.go
@@ -13,12 +13,16 @@ type WorkspaceOwner struct {
 	SSHPublicKey string    `json:"ssh_public_key"`
 	// SSHPrivateKey is intentionally omitted for now, due to the security risk
 	// that exposing it poses.
-	// SSHPrivateKey   string                   `json:"ssh_private_key"`
-	Groups          []string                 `json:"groups"`
-	SessionToken    string                   `json:"session_token"`
-	OIDCAccessToken string                   `json:"oidc_access_token"`
-	LoginType       string                   `json:"login_type"`
-	RBACRoles       []WorkspaceOwnerRBACRole `json:"rbac_roles"`
+	// SSHPrivateKey string `json:"ssh_private_key"`
+	Groups []string `json:"groups"`
+	// SessionToken is intentionally omitted for now, due to the security risk
+	// that exposing it poses.
+	// SessionToken string `json:"session_token"`
+	// OIDCAccessToken is intentionally omitted for now, due to the security risk
+	// that exposing it poses.
+	// OIDCAccessToken string `json:"oidc_access_token"`
+	LoginType string                   `json:"login_type"`
+	RBACRoles []WorkspaceOwnerRBACRole `json:"rbac_roles"`
 }
 
 type WorkspaceOwnerRBACRole struct {


### PR DESCRIPTION
access tokens are roughly as sensitive as the ssh private key, idk why they didn't trigger the same "oh this is sensitive" response in my brain initially 😅