### PR TITLE
chore: implement ExportOutputs locally

### DIFF
--- a/hclext/outputs.go
+++ b/hclext/outputs.go
@@ -1,0 +1,18 @@
+package hclext
+
+import (
+	"github.com/aquasecurity/trivy/pkg/iac/terraform"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func ExportOutputs(modules terraform.Modules) cty.Value {
+	data := make(map[string]cty.Value)
+	for _, block := range modules.GetBlocks().OfType("output") {
+		attr := block.GetAttribute("value")
+		if attr.IsNil() {
+			continue
+		}
+		data[block.Label()] = attr.Value()
+	}
+	return cty.ObjectVal(data)
+}

--- a/preview.go
+++ b/preview.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/coder/preview/hclext"
 	"github.com/coder/preview/types"
 )
 
@@ -116,7 +117,7 @@ func Preview(ctx context.Context, input Input, dir fs.FS) (output *Output, diagn
 		}
 	}
 
-	modules, outputs, err := p.EvaluateAll(ctx)
+	modules, _, err := p.EvaluateAll(ctx)
 	if err != nil {
 		return nil, hcl.Diagnostics{
 			{
@@ -126,6 +127,8 @@ func Preview(ctx context.Context, input Input, dir fs.FS) (output *Output, diagn
 			},
 		}
 	}
+	
+	outputs := hclext.ExportOutputs(modules)
 
 	diags := make(hcl.Diagnostics, 0)
 	rp, rpDiags := parameters(modules)


### PR DESCRIPTION
This code was removed from the underlying library.

In preparation for when this version of the library is used: https://github.com/aquasecurity/trivy/pull/8587