### PR TITLE
feat: handle expanded parameter names

### DIFF
--- a/paramhook.go
+++ b/paramhook.go
@@ -28,8 +28,15 @@ func parameterContextsEvalHook(input Input) func(ctx *tfcontext.Context, blocks 
 
 			nameAttr := block.GetAttribute("name")
 			nameVal := nameAttr.Value()
-			if !nameVal.Type().Equals(cty.String) {
-				continue // Ignore the errors at this point
+			if !nameVal.IsKnown() {
+				// Wait for it to be known
+				continue
+			}
+
+			if nameVal.IsNull() ||
+				!nameVal.Type().Equals(cty.String) {
+				// Ignore the errors at this point
+				continue
 			}
 
 			//nolint:gocritic // string type asserted

--- a/preview_test.go
+++ b/preview_test.go
@@ -132,6 +132,8 @@ func Test_Extract(t *testing.T) {
 				"Region": ap().
 					value("eu").
 					optVals("us", "eu", "au"),
+				"indexed_0": ap(),
+				"indexed_1": ap(),
 			},
 		},
 		{

--- a/testdata/dynamicblock/main.tf
+++ b/testdata/dynamicblock/main.tf
@@ -12,6 +12,24 @@ variable "regions" {
   default = ["us", "eu", "au"]
 }
 
+data "coder_parameter" "indexed" {
+  count = 2
+  name = "indexed_${count.index}"
+  display_name = "Indexed Param ${count.index}"
+  type = "string"
+  form_type = "dropdown"
+  default = "Hello_0"
+
+  dynamic "option" {
+    for_each = range(2)
+
+    content {
+      name  = "Hello_${option.value}"
+      value = "Hello_${option.value}"
+    }
+  }
+}
+
 data "coder_parameter" "region" {
   name        = "Region"
   description = "Which region would you like to deploy to?"


### PR DESCRIPTION
When using a `count` meta argument, the `nameVal` is unknown. Skip unknown `nameVals`. `parameterContextsEvalHook` is called on each evaluation loop, so eventually it will be known.