### PR TITLE
feat: allow bool + number tag values

### DIFF
--- a/preview_test.go
+++ b/preview_test.go
@@ -53,15 +53,14 @@ func Test_Extract(t *testing.T) {
 			name: "sometags",
 			dir:  "sometags",
 			expTags: map[string]string{
-				"string":  "foo",
-				"number":  "42",
-				"bool":    "true",
-				"list":    `["a", "b", "c"]`,
-				"map":     `{"key1": "value1", "key2": "value2"}`,
-				"complex": `{"nested": {"key": "value"}, "nested_list": [1, 2, 3]}`,
-				"null":    "null",
+				"string": "foo",
+				"number": "42",
+				"bool":   "true",
+				// null tags are omitted
 			},
-			unknownTags: []string{},
+			unknownTags: []string{
+				"complex", "map", "list",
+			},
 		},
 		{
 			name: "simple static values",

--- a/preview_test.go
+++ b/preview_test.go
@@ -50,12 +50,27 @@ func Test_Extract(t *testing.T) {
 			failPreview: true,
 		},
 		{
+			name: "sometags",
+			dir:  "sometags",
+			expTags: map[string]string{
+				"string": "foo",
+				"number": "42",
+				"bool":   "true",
+				"extra":  "bar",
+			},
+			unknownTags: []string{
+				"map", "list", "null",
+			},
+		},
+		{
 			name: "simple static values",
 			dir:  "static",
 			expTags: map[string]string{
 				"zone": "developers",
 			},
-			unknownTags: []string{},
+			unknownTags: []string{
+				"list",
+			},
 			params: map[string]assertParam{
 				"region": ap().value("us").
 					def("us").

--- a/preview_test.go
+++ b/preview_test.go
@@ -53,14 +53,16 @@ func Test_Extract(t *testing.T) {
 			name: "sometags",
 			dir:  "sometags",
 			expTags: map[string]string{
-				"string": "foo",
-				"number": "42",
-				"bool":   "true",
-				"extra":  "bar",
+				"string":  "foo",
+				"number":  "42",
+				"bool":    "true",
+				"extra":   "bar",
+				"list":    `["a", "b", "c"]`,
+				"map":     `{"key1": "value1", "key2": "value2"}`,
+				"complex": `{"nested": {"key": "value"}, "nested_list": [1, 2, 3]}`,
+				"null":    "null",
 			},
-			unknownTags: []string{
-				"map", "list", "null",
-			},
+			unknownTags: []string{},
 		},
 		{
 			name: "simple static values",
@@ -522,7 +524,18 @@ func Test_Extract(t *testing.T) {
 			// Assert tags
 			validTags := output.WorkspaceTags.Tags()
 
-			assert.Equal(t, tc.expTags, validTags)
+			for k, expected := range tc.expTags {
+				tag, ok := validTags[k]
+				if !ok {
+					t.Errorf("expected tag %q to be present in output, but it was not", k)
+					continue
+				}
+				if tag != expected {
+					assert.JSONEqf(t, expected, tag, "tag %q does not match expected, nor is it a json equivalent", k)
+				}
+			}
+			assert.Equal(t, len(tc.expTags), len(output.WorkspaceTags.Tags()), "unexpected number of tags in output")
+
 			assert.ElementsMatch(t, tc.unknownTags, output.WorkspaceTags.UnusableTags().SafeNames())
 
 			// Assert params

--- a/preview_test.go
+++ b/preview_test.go
@@ -68,9 +68,6 @@ func Test_Extract(t *testing.T) {
 			expTags: map[string]string{
 				"zone": "developers",
 			},
-			unknownTags: []string{
-				"list",
-			},
 			params: map[string]assertParam{
 				"region": ap().value("us").
 					def("us").

--- a/preview_test.go
+++ b/preview_test.go
@@ -56,7 +56,6 @@ func Test_Extract(t *testing.T) {
 				"string":  "foo",
 				"number":  "42",
 				"bool":    "true",
-				"extra":   "bar",
 				"list":    `["a", "b", "c"]`,
 				"map":     `{"key1": "value1", "key2": "value2"}`,
 				"complex": `{"nested": {"key": "value"}, "nested_list": [1, 2, 3]}`,

--- a/testdata/sometags/main.tf
+++ b/testdata/sometags/main.tf
@@ -27,9 +27,3 @@ data "coder_workspace_tags" "custom_workspace_tags" {
   }
 }
 
-
-data "coder_workspace_tags" "custom_workspace_tags" {
-  tags = {
-    "extra" = "bar"
-  }
-}

--- a/testdata/sometags/main.tf
+++ b/testdata/sometags/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+      version = "2.4.0-pre0"
+    }
+  }
+}
+
+data "coder_workspace_tags" "custom_workspace_tags" {
+  tags = {
+    "string" = "foo"
+    "number" = 42
+    "bool"   = true
+    "list"   = ["a", "b", "c"]
+    "map"    = {
+      "key1" = "value1"
+      "key2" = "value2"
+    }
+    "null"  = null
+  }
+}
+
+
+data "coder_workspace_tags" "custom_workspace_tags" {
+  tags = {
+    "extra" = "bar"
+  }
+}

--- a/testdata/sometags/main.tf
+++ b/testdata/sometags/main.tf
@@ -17,6 +17,12 @@ data "coder_workspace_tags" "custom_workspace_tags" {
       "key1" = "value1"
       "key2" = "value2"
     }
+    "complex" = {
+      "nested_list" = [1, 2, 3]
+      "nested"  = {
+        "key" = "value"
+      }
+    }
     "null"  = null
   }
 }

--- a/testdata/sometags/skipe2e
+++ b/testdata/sometags/skipe2e
@@ -1,0 +1,1 @@
+Complex types are not supported by coder provider

--- a/testdata/sometags/skipe2e
+++ b/testdata/sometags/skipe2e
@@ -1,0 +1,1 @@
+Bad tags are not going to play well with terraform apply.

--- a/testdata/sometags/skipe2e
+++ b/testdata/sometags/skipe2e
@@ -1,1 +1,0 @@
-Bad tags are not going to play well with terraform apply.

--- a/testdata/static/main.tf
+++ b/testdata/static/main.tf
@@ -15,6 +15,7 @@ terraform {
 data "coder_workspace_tags" "custom_workspace_tags" {
   tags = {
     "zone"        = "developers"
+    "null"        = null
   }
 }
 

--- a/workspacetags.go
+++ b/workspacetags.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/json"
 
 	"github.com/coder/preview/types"
 )
@@ -47,21 +48,6 @@ func workspaceTags(modules terraform.Modules, files map[string]*hcl.File) (types
 				continue
 			}
 
-			// tagsObj, ok := tagsAttr.HCLAttribute().Expr.(*hclsyntax.ObjectConsExpr)
-			// if !ok {
-			//	diags = diags.Append(&hcl.Diagnostic{
-			//		Severity: hcl.DiagError,
-			//		Summary:  "Incorrect type for \"tags\" attribute",
-			//		// TODO: better error message for types
-			//		Detail:      fmt.Sprintf(`"tags" attribute must be an 'ObjectConsExpr', but got %T`, tagsAttr.HCLAttribute().Expr),
-			//		Subject:     &tagsAttr.HCLAttribute().NameRange,
-			//		Context:     &tagsAttr.HCLAttribute().Range,
-			//		Expression:  tagsAttr.HCLAttribute().Expr,
-			//		EvalContext: block.Context().Inner(),
-			//	})
-			//	continue
-			//}
-
 			var tags []types.Tag
 			tagsValue.ForEachElement(func(key cty.Value, val cty.Value) (stop bool) {
 				r := tagsAttr.HCLAttribute().Expr.Range()
@@ -75,15 +61,7 @@ func workspaceTags(modules terraform.Modules, files map[string]*hcl.File) (types
 
 				return false
 			})
-			// for _, item := range tagsObj.Items {
-			//	tag, tagDiag := newTag(tagsObj, files, item, evCtx)
-			//	if tagDiag != nil {
-			//		diags = diags.Append(tagDiag)
-			//		continue
-			//	}
-			//
-			//	tags = append(tags, tag)
-			//}
+
 			tagBlocks = append(tagBlocks, types.TagBlock{
 				Tags:  tags,
 				Block: block,
@@ -96,73 +74,47 @@ func workspaceTags(modules terraform.Modules, files map[string]*hcl.File) (types
 
 // newTag creates a workspace tag from its hcl expression.
 func newTag(srcRange *hcl.Range, _ map[string]*hcl.File, key, val cty.Value) (types.Tag, *hcl.Diagnostic) {
-	// key, kdiags := expr.KeyExpr.Value(evCtx)
-	// val, vdiags := expr.ValueExpr.Value(evCtx)
-
-	// TODO: ???
-
-	// if kdiags.HasErrors() {
-	//	key = cty.UnknownVal(cty.String)
-	//}
-	// if vdiags.HasErrors() {
-	//	val = cty.UnknownVal(cty.String)
-	//}
-
 	if key.IsKnown() && key.Type() != cty.String {
 		return types.Tag{}, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid key type for tags",
 			Detail:   fmt.Sprintf("Key must be a string, but got %s", key.Type().FriendlyName()),
-			//Subject:  &r,
-			Context: srcRange,
-			//Expression:  expr.KeyExpr,
-			//EvalContext: evCtx,
+			Context:  srcRange,
 		}
 	}
 
 	tag := types.Tag{
 		Key: types.HCLString{
 			Value: key,
-			//ValueDiags: kdiags,
-			//ValueExpr:  expr.KeyExpr,
 		},
 		Value: types.HCLString{
 			Value: val,
-			//ValueDiags: vdiags,
-			//ValueExpr:  expr.ValueExpr,
 		},
 	}
 
-	// If the value is known, but the type is not a string, bool, or number.
-	// Then throw an error. Only the supported types can safely be converted to a string.
-	if !(val.Type() == cty.String || val.Type() == cty.Bool || val.Type() == cty.Number) {
+	switch val.Type() {
+	case cty.String, cty.Bool, cty.Number:
+		// These types are supported and can be safely converted to a string.
+	default:
 		fr := "<nil>"
 		if !val.Type().Equals(cty.NilType) {
 			fr = val.Type().FriendlyName()
 		}
 
-		tag.Value.ValueDiags = tag.Value.ValueDiags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  fmt.Sprintf("Invalid value type for tag %q", tag.KeyString()),
-			Detail:   fmt.Sprintf("Value must be a string, but got %s", fr),
-			//Subject:     &r,
-			Context: srcRange,
-			//Expression:  expr.ValueExpr,
-			//EvalContext: evCtx,
-		})
+		// Unsupported types will be converted to a JSON string representation.
+		jsonData, err := json.Marshal(val, val.Type())
+		if err != nil {
+			tag.Value.ValueDiags = tag.Value.ValueDiags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Invalid value type for tag %q", tag.KeyString()),
+				Detail:   fmt.Sprintf("Value must be a string, but got %s. Attempt to marshal to json: %s", fr, err.Error()),
+				Context:  srcRange,
+			})
+		} else {
+			// Value successfully marshaled to JSON, we can store it as a string.
+			tag.Value.Value = cty.StringVal(string(jsonData))
+		}
 	}
-
-	// ks, err := source(expr.KeyExpr.Range(), files)
-	// if err == nil {
-	//	src := string(ks)
-	//	tag.Key.Source = &src
-	//}
-	//
-	// vs, err := source(expr.ValueExpr.Range(), files)
-	// if err == nil {
-	//	src := string(vs)
-	//	tag.Value.Source = &src
-	//}
 
 	return tag, nil
 }

--- a/workspacetags.go
+++ b/workspacetags.go
@@ -120,23 +120,6 @@ func newTag(srcRange *hcl.Range, _ map[string]*hcl.File, key, val cty.Value) (ty
 		}
 	}
 
-	if val.IsKnown() && val.Type() != cty.String {
-		fr := "<nil>"
-		if !val.Type().Equals(cty.NilType) {
-			fr = val.Type().FriendlyName()
-		}
-		// r := expr.ValueExpr.Range()
-		return types.Tag{}, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid value type for tag",
-			Detail:   fmt.Sprintf("Value must be a string, but got %s", fr),
-			//Subject:     &r,
-			Context: srcRange,
-			//Expression:  expr.ValueExpr,
-			//EvalContext: evCtx,
-		}
-	}
-
 	tag := types.Tag{
 		Key: types.HCLString{
 			Value: key,
@@ -148,6 +131,25 @@ func newTag(srcRange *hcl.Range, _ map[string]*hcl.File, key, val cty.Value) (ty
 			//ValueDiags: vdiags,
 			//ValueExpr:  expr.ValueExpr,
 		},
+	}
+
+	// If the value is known, but the type is not a string, bool, or number.
+	// Then throw an error. Only the supported types can safely be converted to a string.
+	if !(val.Type() == cty.String || val.Type() == cty.Bool || val.Type() == cty.Number) {
+		fr := "<nil>"
+		if !val.Type().Equals(cty.NilType) {
+			fr = val.Type().FriendlyName()
+		}
+
+		tag.Value.ValueDiags = tag.Value.ValueDiags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Invalid value type for tag %q", tag.KeyString()),
+			Detail:   fmt.Sprintf("Value must be a string, but got %s", fr),
+			//Subject:     &r,
+			Context: srcRange,
+			//Expression:  expr.ValueExpr,
+			//EvalContext: evCtx,
+		})
 	}
 
 	// ks, err := source(expr.KeyExpr.Range(), files)

--- a/workspacetags.go
+++ b/workspacetags.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/json"
 
 	"github.com/coder/preview/types"
 )
@@ -50,6 +49,12 @@ func workspaceTags(modules terraform.Modules, files map[string]*hcl.File) (types
 
 			var tags []types.Tag
 			tagsValue.ForEachElement(func(key cty.Value, val cty.Value) (stop bool) {
+				if val.IsNull() {
+					// null tags with null values are omitted
+					// This matches the behavior of `terraform apply``
+					return false
+				}
+
 				r := tagsAttr.HCLAttribute().Expr.Range()
 				tag, tagDiag := newTag(&r, files, key, val)
 				if tagDiag != nil {
@@ -101,19 +106,13 @@ func newTag(srcRange *hcl.Range, _ map[string]*hcl.File, key, val cty.Value) (ty
 			fr = val.Type().FriendlyName()
 		}
 
-		// Unsupported types will be converted to a JSON string representation.
-		jsonData, err := json.Marshal(val, val.Type())
-		if err != nil {
-			tag.Value.ValueDiags = tag.Value.ValueDiags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  fmt.Sprintf("Invalid value type for tag %q", tag.KeyString()),
-				Detail:   fmt.Sprintf("Value must be a string, but got %s. Attempt to marshal to json: %s", fr, err.Error()),
-				Context:  srcRange,
-			})
-		} else {
-			// Value successfully marshaled to JSON, we can store it as a string.
-			tag.Value.Value = cty.StringVal(string(jsonData))
-		}
+		// Unsupported types will be treated as errors.
+		tag.Value.ValueDiags = tag.Value.ValueDiags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Invalid value type for tag %q", tag.KeyString()),
+			Detail:   fmt.Sprintf("Value must be a string, but got %s.", fr),
+			Context:  srcRange,
+		})
 	}
 
 	return tag, nil


### PR DESCRIPTION
Tag values accept bool & number in coder/coder.

Maps, lists, and objects are rejected as invalid tags. `terraform` apply gives this error for 

```terraform
data "coder_workspace_tags" "custom_workspace_tags" {
  tags = {
    "map"    = {
      "value" = "foo"
    }
  }
}
```

```
╷
│ Error: Incorrect attribute value type
│ 
│   on main.tf line 11, in data "coder_workspace_tags" "custom_workspace_tags":
│   11:   tags = {
│   12:     "list"   = ["a", "b", "c"]
│   13:   }
│ 
│ Inappropriate value for attribute "tags": element "list": string required.
╵
```

`null` values are omitted from the tags, matching terraform apply/plan