### PR TITLE
chore: fix nil ptr deref on terraform plan data

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -81,7 +81,11 @@ func planJSONHook(dfs fs.FS, input Input) (func(ctx *tfcontext.Context, blocks t
 // priorPlanModule returns the state data of the module a given block is in.
 func priorPlanModule(plan *tfjson.Plan, block *terraform.Block) *tfjson.StateModule {
 	if !block.InModule() {
-		return plan.PriorState.Values.RootModule
+		// If the block is not in a module, then we can just return the root module.
+		if plan.PriorState != nil && plan.PriorState.Values != nil {
+			return plan.PriorState.Values.RootModule
+		}
+		return nil
 	}
 
 	var modPath []string

--- a/plan.go
+++ b/plan.go
@@ -105,7 +105,7 @@ func priorPlanModule(plan *tfjson.Plan, block *terraform.Block) *tfjson.StateMod
 	for i := range modPath {
 		idx := slices.IndexFunc(current.ChildModules, func(m *tfjson.StateModule) bool {
 			if m == nil {
-				return false // Avoid nil pointer dereference
+				return false
 			}
 			return m.Address == strings.Join(modPath[:i+1], ".")
 		})

--- a/plan.go
+++ b/plan.go
@@ -80,12 +80,15 @@ func planJSONHook(dfs fs.FS, input Input) (func(ctx *tfcontext.Context, blocks t
 
 // priorPlanModule returns the state data of the module a given block is in.
 func priorPlanModule(plan *tfjson.Plan, block *terraform.Block) *tfjson.StateModule {
+	if plan.PriorState == nil || plan.PriorState.Values == nil {
+		return nil // No root module available in the plan, nothing to do
+	}
+
+	rootModule := plan.PriorState.Values.RootModule
+
 	if !block.InModule() {
 		// If the block is not in a module, then we can just return the root module.
-		if plan.PriorState != nil && plan.PriorState.Values != nil {
-			return plan.PriorState.Values.RootModule
-		}
-		return nil
+		return rootModule
 	}
 
 	var modPath []string
@@ -98,9 +101,12 @@ func priorPlanModule(plan *tfjson.Plan, block *terraform.Block) *tfjson.StateMod
 		}
 	}
 
-	current := plan.PriorState.Values.RootModule
+	current := rootModule
 	for i := range modPath {
 		idx := slices.IndexFunc(current.ChildModules, func(m *tfjson.StateModule) bool {
+			if m == nil {
+				return false // Avoid nil pointer dereference
+			}
 			return m.Address == strings.Join(modPath[:i+1], ".")
 		})
 		if idx == -1 {


### PR DESCRIPTION
Could hit a deref if the plan was empty.