### PR TITLE
ci: add gofmt check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,3 +36,16 @@ jobs:
           key: golangci-lint-${{ runner.os }}-${{ hashFiles('**/*.go') }}
           restore-keys: |
             golangci-lint-${{ runner.os }}-
+
+  fmt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.8
+      - name: make fmt
+        run: make fmt
+      - name: Check for unstaged files
+        run: ./scripts/check_unstaged.sh

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,7 @@ gen:
 .PHONY: clean-testdata
 clean-testdata:
 	git clean -xfd testdata
+
+.PHONY: fmt
+fmt:
+	gofmt -w .

--- a/types/diagnostics_test.go
+++ b/types/diagnostics_test.go
@@ -40,7 +40,7 @@ func TestDiagnosticExtra(t *testing.T) {
 // The `parent` wrapped is lost here, so calling `SetDiagnosticExtra` is
 // lossy. In practice, we only call this once, so it's ok.
 // TODO: Fix SetDiagnosticExtra to maintain the parents
-//  if the DiagnosticExtra already exists in the chain.
+// if the DiagnosticExtra already exists in the chain.
 func TestDiagnosticExtraExisting(t *testing.T) {
 	diag := &hcl.Diagnostic{
 		Severity: hcl.DiagWarning,


### PR DESCRIPTION
Adds a formatting check to CI that fails when any Go file is not `gofmt`-clean.

Nothing in CI catches unformatted Go today: `.github/workflows/lint.yml` installs `golangci-lint` but never runs it. This change adds a `fmt` job to the same workflow that runs `make fmt` and uses the existing `scripts/check_unstaged.sh` to fail on any diff. `types/diagnostics_test.go` was already not `gofmt`-clean on `main`; that reformat is included as a separate commit.

Generated with Coder Agents.
