### PR TITLE
chore: enable coder_secret e2e tests on coder provider 2.16.0

### DIFF
--- a/testdata/secretsbasic/main.tf
+++ b/testdata/secretsbasic/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+      version = "2.16.0"
+    }
+  }
+}
+
 data "coder_secret" "gh" {
   env          = "GITHUB_TOKEN"
   help_message = "Add a GitHub PAT"

--- a/testdata/secretsbasic/skipe2e
+++ b/testdata/secretsbasic/skipe2e
@@ -1,1 +1,0 @@
-coder_secret is not yet in the released coder provider

--- a/testdata/secretsconditional/main.tf
+++ b/testdata/secretsconditional/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+      version = "2.16.0"
+    }
+  }
+}
+
 data "coder_parameter" "use_github" {
   name    = "use_github"
   type    = "bool"

--- a/testdata/secretsconditional/skipe2e
+++ b/testdata/secretsconditional/skipe2e
@@ -1,1 +1,0 @@
-coder_secret is not yet in the released coder provider


### PR DESCRIPTION
Follow up from my [previous PR](https://github.com/coder/preview/pull/198), enabling tests that were being skipped